### PR TITLE
chore: 添加运行测试的最大堆内存

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ allprojects {
 
     test {
         systemProperty "java.util.logging.manager", "org.jboss.logmanager.LogManager"
+
+        maxHeapSize = '2g'
     }
     compileJava {
         options.encoding = 'UTF-8'


### PR DESCRIPTION
不设置最大堆内存时，如果单元测试过多，可能会 OOM