### PR TITLE
refactor-IUpdateAbility-添加 beforeUpdate(id, body) 方法

### DIFF
--- a/muyun-core/src/main/java/net/ximatai/muyun/ability/curd/std/IUpdateAbility.java
+++ b/muyun-core/src/main/java/net/ximatai/muyun/ability/curd/std/IUpdateAbility.java
@@ -20,13 +20,22 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * 修改数据的能力
  */
 public interface IUpdateAbility extends IDatabaseAbilityStd, IMetadataAbility {
 
+    /**
+     * @deprecated 请使用带 Map 参数的 beforeUpdate 方法，这个方法将在未来的版本中移除
+     */
+    @Deprecated(forRemoval = true)
     default void beforeUpdate(String id) {
+
+    }
+
+    default void beforeUpdate(String id, Optional<Map> body) {
 
     }
 
@@ -40,6 +49,7 @@ public interface IUpdateAbility extends IDatabaseAbilityStd, IMetadataAbility {
     @Operation(summary = "修改数据", description = "返回被修改数据的数量，正常为1")
     default Integer update(@PathParam("id") String id, Map body) {
         beforeUpdate(id);
+        beforeUpdate(id, Optional.of(body));
         HashMap map = new HashMap(body);
         map.put(getPK(), id);
         map.put("t_update", LocalDateTime.now());

--- a/muyun-platform/src/main/java/net/ximatai/muyun/platform/controller/OutboxController.java
+++ b/muyun-platform/src/main/java/net/ximatai/muyun/platform/controller/OutboxController.java
@@ -6,6 +6,7 @@ import net.ximatai.muyun.model.PageResult;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static net.ximatai.muyun.platform.PlatformConst.BASE_PATH;
 
@@ -18,7 +19,7 @@ public class OutboxController extends MessageController {
     }
 
     @Override
-    public void beforeUpdate(String id) {
+    public void beforeUpdate(String id, Optional<Map> body) {
         PageResult query = this.query(Map.of(
             "id_at_app_message__root", id
         ));
@@ -29,6 +30,6 @@ public class OutboxController extends MessageController {
 
     @Override
     public void beforeDelete(String id) {
-        this.beforeUpdate(id);
+        this.beforeUpdate(id, Optional.empty());
     }
 }


### PR DESCRIPTION
`beforeUpdate(String id, Optional<Map> body)` 是否会给使用者带来困惑，按照字面意思理解，`beforeUpdate` 带有 body 参数，而此处 body 可以为空